### PR TITLE
replacing hqtest.tst with the url from the README

### DIFF
--- a/qs-01-python-embed-signing-ceremony.py
+++ b/qs-01-python-embed-signing-ceremony.py
@@ -9,7 +9,7 @@ from docusign_esign import ApiClient, EnvelopesApi, EnvelopeDefinition, Signer, 
 # Settings
 # Fill in these constants
 #
-# Obtain an OAuth access token from https://developers.hqtest.tst/oauth-token-generator
+# Obtain an OAuth access token from https://developers.docusign.com/oauth-token-generator
 access_token = '{ACCESS_TOKEN}'
 # Obtain your accountId from demo.docusign.com -- the account id is shown in the drop down on the
 # upper right corner of the screen by your picture or the default picture. 

--- a/qs-02-python-send-envelope.py
+++ b/qs-02-python-send-envelope.py
@@ -8,7 +8,7 @@ from docusign_esign import ApiClient, EnvelopesApi, EnvelopeDefinition, Signer, 
 # Settings
 # Fill in these constants
 #
-# Obtain an OAuth access token from https://developers.hqtest.tst/oauth-token-generator
+# Obtain an OAuth access token from https://developers.docusign.com/oauth-token-generator
 access_token = '{ACCESS_TOKEN}'
 # Obtain your accountId from demo.docusign.com -- the account id is shown in the drop down on the
 # upper right corner of the screen by your picture or the default picture. 

--- a/qs-03-python-list-envelopes.py
+++ b/qs-03-python-list-envelopes.py
@@ -10,7 +10,7 @@ import pprint
 # Settings
 # Fill in these constants
 #
-# Obtain an OAuth access token from https://developers.hqtest.tst/oauth-token-generator
+# Obtain an OAuth access token from https://developers.docusign.com/oauth-token-generator
 access_token = '{ACCESS_TOKEN}'
 # Obtain your accountId from demo.docusign.com -- the account id is shown in the drop down on the
 # upper right corner of the screen by your picture or the default picture. 


### PR DESCRIPTION
I'm not sure what hqtest.tst was, but it's a domain squatter now. The url in the README worked fine.